### PR TITLE
Update README to list incompatible devices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Tested On Android Kitkat 4.4
   Going adb shell run-as will produce the hang  
 2) 
   Android 5 (Samsung Galaxy S4)  
-  setresgid/setresuid failed  
-  
+  setresgid/setresuid failed
+3)
+  Incompatible with devices with system partitions made read-only by the _hardware_, such as the DigiLand DL718M and other supercheap devices.
 Oringal PoC Code: https://github.com/timwr/CVE-2016-5195

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Tested On Android Kitkat 4.4
 2) 
   Android 5 (Samsung Galaxy S4)  
   setresgid/setresuid failed
+  
 3)
   Incompatible with devices with system partitions made read-only by the _hardware_, such as the DigiLand DL718M and other supercheap devices.
 Oringal PoC Code: https://github.com/timwr/CVE-2016-5195


### PR DESCRIPTION
I recently discovered that my device was completely unsusceptible to this rootkit because the hardware physically prevents writing to the system partition. I suggest that the README let other people know about this. 
The related issue is here: https://github.com/Tlgyt/DirtyCowAndroid/issues/1